### PR TITLE
fix

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,10 +36,9 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : "../../placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
-        onError={(event) => event.target.src = '../../placeholder.png'}
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -39,6 +39,7 @@ const ItemPreview = (props) => {
         src={item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
+        onError={(event) => event.target.src = '../../placeholder.png'}
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">


### PR DESCRIPTION
Fix broken image display

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

When creating a new product without an image, there are broken images showing up in the product catalog
Fixes this by adding a placeholder img when error arises
<img width="808" alt="Screen Shot 2022-08-11 at 11 05 15 AM" src="https://user-images.githubusercontent.com/40643552/184208606-f5efd660-a63f-49e0-91ff-bf543db0272f.png">

