### PR TITLE
fix

### DIFF
--- a/backend/app/db/repositories/items.py
+++ b/backend/app/db/repositories/items.py
@@ -42,6 +42,8 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
         image: Optional[str] = None,
         tags: Optional[Sequence[str]] = None,
     ) -> Item:
+        if image == "" or image is None:
+            image = "../../../frontend/public/placeholder.png"
         async with self.connection.transaction():
             item_row = await queries.create_new_item(
                 self.connection,


### PR DESCRIPTION
# Description

- When items are uploaded without image, the backend does not reflect the broken image placeholder. 
- This fix is for the backend to ensure that broken images are stored with a placeholder
